### PR TITLE
Change pvp-bounds default, automate resolver selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      # Can be created at https://hackage.haskell.org/user/{username}/manage
       HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
     steps:
       - uses: actions/checkout@v2
@@ -19,15 +18,45 @@ jobs:
 ## Inputs
 
 - `working-directory`: directory to work in, default is `.`
-- `pvp-bounds`: `--pvp-bounds` argument to pass, default is `none`.
+- `pvp-bounds`: `--pvp-bounds` argument to pass, default is `lower`.
+
+## Environment
+
+- `STACK_YAML`: the `stack.yaml` to use for bounds-setting (optional)
+- `HACKAGE_API_KEY`: an Authentication Token with rights to upload (required)
+
+  See `https://hackage.haskell.org/user/{username}/manage` to create one.
+
+## PVP Bounds
+
+Under certain circumstances, this Action may choose a "better" `stack.yaml` for
+the purposes of bounds-setting.
+
+If you:
+
+- Are using `pvp-bounds: lower` (the default)
+- Have not set a `$STACK_YAML`
+- Have multiple files of the form `stack-lts-*.yaml`
+
+the Action will select the oldest, version-sorted `stack-lts-*.yaml` file.
+
+This leads to wider (and more accurate) compatibility for your package, assuming
+this is the oldest set of dependencies you test against and thus more accurately
+describes your true lower bounds.
+
+To avoid this, ensure any one of the conditions above is not met.
 
 ## FAQ
 
 - Why not `stack upload`?
 
   `stack upload` supports only Username and Password; it does not support API
-  Keys in requests to Hackage. API Keys can be created or revoked for specific
+  Keys in requests to Hackage\*. API Keys can be created or revoked for specific
   uses or repositories, and so make much more sense in CI.
+
+  \*This has [been implemented][stack-commit], but not yet released.
+
+  [stack-commit]: https://github.com/hololeap/stack/commit/a2eff4d023148aeac288029b91ec531e5e120092
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,27 @@ inputs:
     required: true
     default: .
   pvp-bounds:
-    description: "--pvp-bounds to use (none, lower, upper, or both)"
+    description: "--pvp-bounds to use: none, lower (default), upper, or both"
     required: true
-    default: none
+    default: lower
 outputs: {}
 runs:
   using: composite
   steps:
+    - if: ${{ inputs.pvp-bounds == 'lower' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [[ -n "$STACK_YAML" ]]; then
+          exit 0 # respect
+        fi
+
+        read -r stack_yaml < \
+          <(find . -name 'stack-lts-*.yaml' | sort -V; echo stack.yaml)
+
+        echo "Setting STACK_YAML=$stack_yaml, to inform --pvp-bounds=lower"
+        echo "STACK_YAML=$stack_yaml" >> '${{ github.env }}'
+
     - name: Release
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
As described in the `README`, when using `--pvp-bounds=lower` you want
to use the lowest bounds you test with. Concretely, this often means the
`stack-lts-*.yaml` that is the earliest resolver. This can be worked out
trivially, so let's do that and stop our end-users (also us) from having
to.

It also seems reasonable for this Action to use our own preferred
defaults (when they're not super objectionable, as is this case); so
let's do that as well.
