### PR TITLE
Replace set-output with GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         tmp=$(mktemp -d)
         stack sdist --tar-dir "$tmp" --pvp-bounds ${{ inputs.pvp-bounds }} .
         archive=$(find "$tmp" -name '*.tar.gz' -print)
-        echo "::set-output name=archive::$archive"
+        echo "archive=$archive" >> "$GITHUB_OUTPUT"
         echo "::endgroup::"
 
         if [ -z "$archive" ]; then


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
